### PR TITLE
Replace LaTex ellipses into original ellipses before sentence spiltting

### DIFF
--- a/modifytext.py
+++ b/modifytext.py
@@ -50,6 +50,8 @@ def split_text_to_sentences_en(text):
 
     """
 
+    text = text.replace(" . . . ","...") #replace LaTex ellipses with original ellipses
+    
     sents = re.split(r'(?<!\w\.\w.)(?<![A-Z][a-z]\.)(?<=\.|\?)\s', text)
 
     return sents


### PR DESCRIPTION
replace the copied LaTex ellipses content into original ellipses text, making the sentence splitting function (en) work better.

* LaTex ellipses: ` . . . `
* original ellipses: `...`

_\*noted: i didn't recompile the executable file._